### PR TITLE
Twitter連携時のAPIエンドポイントを変更

### DIFF
--- a/NCMB/NCMBTwitter/NCMBTwitterLoginView.m
+++ b/NCMB/NCMBTwitter/NCMBTwitterLoginView.m
@@ -212,7 +212,7 @@ enum{
     UIView* bg = [self.webView viewWithTag:ActivityIndicatorBackgroundTag];
     [bg removeFromSuperview];
     
-    NSString *html = @"<html><body><h1>ページを開けません。</h1></body></html>";
+    NSString *html = @"<html><body><h1>Twitterアカウントでのログインに失敗しました。<br/>ポップアップ画面を閉じて、ログインをもう一度行ってください。</h1></body></html>";
     NSData *bodyData = [html dataUsingEncoding:NSUTF8StringEncoding];
     [self.webView loadData:bodyData MIMEType:@"text/html" textEncodingName:@"utf-8" baseURL:nil];
 }

--- a/NCMB/NCMBTwitter/NCMB_Twitter.m
+++ b/NCMB/NCMBTwitter/NCMB_Twitter.m
@@ -282,7 +282,6 @@ enum{
 shouldStartLoadWithRequest:(NSURLRequest*) request
   navigationType:(UIWebViewNavigationType) navigationType
 {
-    
     // WebView内でリンクをクリックした際に、認証と無関係な遷移を捕捉してSafariで開く処理
     if (navigationType == UIWebViewNavigationTypeLinkClicked) {
         NSRange range = [[request.URL absoluteString] rangeOfString:@"https://api.twitter.com/"];
@@ -320,6 +319,12 @@ shouldStartLoadWithRequest:(NSURLRequest*) request
             return NO;
         }
 
+    }
+    
+    //iOS9かつ、一度Twitter認証で失敗して、/login/errorにアクセスしようとしている場合をエラーとする
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_3 &&
+        [[request.URL absoluteString] containsString:@"https://api.twitter.com/login/error"]) {
+        return NO;
     }
     
     NSMutableDictionary* params = [NSMutableDictionary dictionaryWithCapacity:0];

--- a/NCMB/NCMBTwitter/NCMB_Twitter.m
+++ b/NCMB/NCMBTwitter/NCMB_Twitter.m
@@ -23,9 +23,9 @@
 #import "NCMBURLConnection.h"
 #import "NCMBTwitterLoginView.h"
 
-#define AUTHORIZE_URL @"https://twitter.com/oauth/authorize"
+#define AUTHORIZE_URL @"https://api.twitter.com/oauth/authorize"
 #define REQUEST_TOKEN_URL @"https://api.twitter.com/oauth/request_token"
-#define TOKEN_FORMAT_URL @"https://twitter.com/oauth/authorize?oauth_token=%@"
+#define TOKEN_FORMAT_URL @"https://api.twitter.com/oauth/authorize?oauth_token=%@"
 
 #define SIGNATURE_METHOD @"HMAC-SHA1"
 #define OAUTH_VERSION @"1.0"
@@ -282,6 +282,7 @@ enum{
 shouldStartLoadWithRequest:(NSURLRequest*) request
   navigationType:(UIWebViewNavigationType) navigationType
 {
+    
     // WebView内でリンクをクリックした際に、認証と無関係な遷移を捕捉してSafariで開く処理
     if (navigationType == UIWebViewNavigationTypeLinkClicked) {
         NSRange range = [[request.URL absoluteString] rangeOfString:@"https://api.twitter.com/"];
@@ -331,7 +332,7 @@ shouldStartLoadWithRequest:(NSURLRequest*) request
     if([[params allKeys] containsObject:@"oauth_verifier"]){
         NSString* oauth_verifier = params[@"oauth_verifier"];
         [self requestOAuthAccessTokenWithVerifier:oauth_verifier];
-        return YES;
+        return NO;
     }
     
     return YES;


### PR DESCRIPTION
#26 にある、iOS9でのTwitter連携機能の不具合を修正しました

- エンドポイントをapi.twitter.comにすることで、universal linkによるアプリの起動を抑止しました
- callbackUrlの読み込みを行わないようにしました