### PR TITLE
Fix issue #22

### DIFF
--- a/NCMB/NCMBURLConnection/NCMBURLConnection.h
+++ b/NCMB/NCMBURLConnection/NCMBURLConnection.h
@@ -16,7 +16,6 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>
-#import <CommonCrypto/CommonCrypto.h>
 #import <UIKit/UIKit.h>
 
 @class NCMBUser;

--- a/NCMB/NCMBURLConnection/NCMBURLConnection.m
+++ b/NCMB/NCMBURLConnection/NCMBURLConnection.m
@@ -20,6 +20,7 @@
 #import "NCMBUser+Private.h"
 #import "NCMBError.h"
 #import "NCMBConstants.h"
+#import <CommonCrypto/CommonCrypto.h>
 
 static NSString *const kEndPoint            = @"https://mb.api.cloud.nifty.com";
 static NSString *const kAPIVersion          = @"2013-09-01";


### PR DESCRIPTION
Issue22の対応です。
ヘッダー内で非モジュールをimportするとエラーが発生するようなので実装ファイルでimportするようにしました。

```objc
#import <CommonCrypto/CommonCrypto.h>
```
