### PR TITLE
Fix issue #33

### DIFF
--- a/NCMB/NCMBGoogleUtils+Private.h
+++ b/NCMB/NCMBGoogleUtils+Private.h
@@ -14,6 +14,10 @@
  limitations under the License.
  */
 
+//Googleのライブラリがある場合はビルド対象に含める
+#if defined(__has_include)
+#if __has_include(<GoogleSignIn/GoogleSignIn.h>)
+
 #import "NCMBGoogleUtils.h"
 
 @interface NCMBGoogleUtils (Private)
@@ -25,3 +29,6 @@
 +(void)clearGoogleSession;
 
 @end
+
+#endif
+#endif


### PR DESCRIPTION
`NCMBGoogleUtils`の宣言には下記のif文がありましたが、`NCMBGoogleUtils+Private`にはif文がなかった為エラーが発生していました。
`NCMBGoogleUtils+Private`の方にもif文を追加する事で対策しました。

```objc
#if defined(__has_include)
#if __has_include(<GoogleSignIn/GoogleSignIn.h>)

#end
#end
```