### PR TITLE
issues #46 Twitter認証機能で、iPadでのTwitter新規登録ができない

### DIFF
--- a/NCMB/NCMBTwitter/NCMB_Twitter.m
+++ b/NCMB/NCMBTwitter/NCMB_Twitter.m
@@ -286,16 +286,22 @@ shouldStartLoadWithRequest:(NSURLRequest*) request
     if (navigationType == UIWebViewNavigationTypeLinkClicked) {
         NSRange range = [[request.URL absoluteString] rangeOfString:@"https://api.twitter.com/"];
         if (range.location == NSNotFound) {
-            UIWindow* window = [UIApplication sharedApplication].windows[0];
+            
+            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+                // iPadではアクションシートを使わず直接Safariで開く
+                [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[[request URL] absoluteString]]];
+            } else {
+                UIWindow* window = [UIApplication sharedApplication].windows[0];
                 
-            UIActionSheet *actionSheet = [[UIActionSheet alloc] init];
-            actionSheet.delegate = self;
-            actionSheet.title = [[request URL] absoluteString];
-            [actionSheet addButtonWithTitle:@"Safariで開く"];
-            [actionSheet addButtonWithTitle:@"キャンセル"];
-            actionSheet.cancelButtonIndex = 1;
+                UIActionSheet *actionSheet = [[UIActionSheet alloc] init];
+                actionSheet.delegate = self;
+                actionSheet.title = [[request URL] absoluteString];
+                [actionSheet addButtonWithTitle:@"Safariで開く"];
+                [actionSheet addButtonWithTitle:@"キャンセル"];
+                actionSheet.cancelButtonIndex = 1;
                 
-            [actionSheet showInView:window];
+                [actionSheet showInView:window];
+            }
 
             return NO;
         }


### PR DESCRIPTION
iPadでTwitterの新規登録ができるように修正しました。

iPhoneとiPadでは、actionSheetの表示方法が異なるため、以下の処理をしないといけないのですが、
・iPhone
[actionSheet showInView: self.view.window];
・iPad
[actionSheet showInView: self.view];

mBaaS SDKでは、
UIWindow* window = [UIApplication sharedApplication].windows[0];
で表示させているため、iPad用に、
[actionSheet showInView: window.rootViewController.view];
と設定しても、webViewの後ろ側に表示されてしまいます。

それはAlertControllerでも同様の結果になります。

そのため、今回の修正では、iPadではactionSheetを表示させず、直接ブラウザに遷移するように修正しました。ご確認お願いいたします。