### PR TITLE
#58 子ロールや会員が存在しないロールに対しての操作ができない

### DIFF
--- a/NCMB/NCMBRole.m
+++ b/NCMB/NCMBRole.m
@@ -71,6 +71,10 @@
  @param user 追加する会員
  */
 - (void)addUser:(NCMBUser*)user{
+    //ロールに属するユーザー情報がNSArrayだった場合はリレーションを新規作成する
+    if ([_users isKindOfClass:[NSArray class]]) {
+        _users = [self relationforKey:@"belongUser"];
+    }
     //プロパティの更新
     [_users addObject:(NCMBObject*)user];
     
@@ -81,6 +85,10 @@
  @param role 追加するロール
  */
 - (void)addRole:(NCMBRole*)role{
+    //ロールに属する子ロール情報がNSArrayだった場合はリレーションを新規作成する
+    if ([_roles isKindOfClass:[NSArray class]]) {
+        _roles = [self relationforKey:@"belongRole"];
+    }
     //プロパティの更新
     [_roles addObject:(NCMBObject*)role];
 }

--- a/NCMBTests/NCMBTests.xcodeproj/project.pbxproj
+++ b/NCMBTests/NCMBTests.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		5D40F2941C578B6D00358E63 /* NCMBRequestSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D40F2931C578B6D00358E63 /* NCMBRequestSpec.m */; };
 		5D69FBAA1C55D9FD00526E87 /* NCMBScriptServiceSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D69FBA91C55D9FD00526E87 /* NCMBScriptServiceSpec.m */; };
 		5DAF49AE1C5080DC0012F4DA /* NCMBScriptSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DAF49AD1C5080DC0012F4DA /* NCMBScriptSpec.m */; };
+		9DA4F0FF1D0FDCFB0090AD5B /* NCMBRoleSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA4F0FE1D0FDCFB0090AD5B /* NCMBRoleSpec.m */; };
 		DA4A60A010626E247AF35325 /* libPods-NCMBTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B70F2F83AA3F5861F40A1CE /* libPods-NCMBTests.a */; };
 /* End PBXBuildFile section */
 
@@ -21,6 +22,7 @@
 		5DE7EB6A1C5075000082ED93 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		724CF6FBB40BF7A1421D5E2B /* Pods-NCMBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NCMBTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NCMBTests/Pods-NCMBTests.release.xcconfig"; sourceTree = "<group>"; };
 		7B70F2F83AA3F5861F40A1CE /* libPods-NCMBTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NCMBTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9DA4F0FE1D0FDCFB0090AD5B /* NCMBRoleSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCMBRoleSpec.m; sourceTree = "<group>"; };
 		A9A51BAA7673E88272305FBD /* Pods-NCMBTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NCMBTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-NCMBTests/Pods-NCMBTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -70,6 +72,7 @@
 				5D69FBA91C55D9FD00526E87 /* NCMBScriptServiceSpec.m */,
 				5DAF49AD1C5080DC0012F4DA /* NCMBScriptSpec.m */,
 				5D40F2931C578B6D00358E63 /* NCMBRequestSpec.m */,
+				9DA4F0FE1D0FDCFB0090AD5B /* NCMBRoleSpec.m */,
 			);
 			path = NCMBTests;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 				5DAF49AE1C5080DC0012F4DA /* NCMBScriptSpec.m in Sources */,
 				5D69FBAA1C55D9FD00526E87 /* NCMBScriptServiceSpec.m in Sources */,
 				5D40F2941C578B6D00358E63 /* NCMBRequestSpec.m in Sources */,
+				9DA4F0FF1D0FDCFB0090AD5B /* NCMBRoleSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NCMBTests/NCMBTests/NCMBRoleSpec.m
+++ b/NCMBTests/NCMBTests/NCMBRoleSpec.m
@@ -1,0 +1,79 @@
+/*
+ Copyright 2016 NIFTY Corporation All Rights Reserved.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "Specta.h"
+#import <Expecta/Expecta.h>
+#import <NCMB/NCMB.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+@interface NCMBRole (Private)
+@property (nonatomic) NCMBRelation *users;
+@property (nonatomic) NCMBRelation *roles;
+@end
+
+SpecBegin(NCMBRole)
+
+describe(@"NCMBRole", ^{
+
+    beforeAll(^{
+        
+    });
+    
+    beforeEach(^{
+
+    });
+    
+    it(@"should create new relations if belong user was NSArray", ^{
+        
+        NCMBUser *user = [NCMBUser user];
+        user.userName = @"freeUser";
+        user.password = @"pass";
+        user.objectId = @"aaaaaaaa";
+        
+        NCMBRole *role = [NCMBRole roleWithName:@"freePlan"];
+        role.users = (NCMBRelation *)[NSArray new];
+        
+        [role addUser:user];
+        
+        expect([role.users class]).to.equal([NCMBRelation class]);
+        
+    });
+
+    it(@"should create new relations if belong role was NSArray", ^{
+        
+        NCMBRole *administrators = [NCMBRole roleWithName:@"Administrators"];
+        administrators.objectId = @"aaaaaaaa";
+        
+        NCMBRole *moderators = [NCMBRole roleWithName:@"Moderators"];
+        moderators.roles = (NCMBRelation *)[NSArray new];
+        
+        [moderators addRole:administrators];
+        
+        expect([moderators.roles class]).to.equal([NCMBRelation class]);
+        
+    });
+    
+    afterEach(^{
+
+    });
+    
+    afterAll(^{
+
+    });
+});
+
+SpecEnd


### PR DESCRIPTION
## 概要(Summary)

- Fixed #58
* 子ロールや会員が存在しないロールで追加処理が出来るように修正
* テストコードの追加

## 動作確認手順(Step for Confirmation)

Run the NCMBRoleSpec.
