### PR TITLE
メールアドレスが確認済みかを把握するメソッドの追加

### DIFF
--- a/NCMB/NCMBUser.h
+++ b/NCMB/NCMBUser.h
@@ -338,4 +338,13 @@
 - (void)unlink:(NSString *)type
      withBlock:(NCMBErrorResultBlock)block;
 
+#pragma mark - mailAddressConfirm
+/** @name mailAddressConfirm */
+
+/**
+ メールアドレスが確認済みのものかを把握する
+ @return メールアドレスが確認済みの場合はYESを返す
+ */
+- (BOOL)isMailAddressConfirm;
+
 @end

--- a/NCMB/NCMBUser.m
+++ b/NCMB/NCMBUser.m
@@ -1059,4 +1059,15 @@ static BOOL isEnableAutomaticUser = NO;
     }
 }
 
+#pragma mark - mailAddressConfirm
+
+/**
+ メールアドレスが確認済みのものかを把握する
+ @return メールアドレスが確認済みの場合はYESを返す
+ */
+- (BOOL)isMailAddressConfirm{
+    
+    return [self objectForKey:@"mailAddressConfirm"]!= [NSNull null] && [[self objectForKey:@"mailAddressConfirm"]boolValue] ? YES : NO;
+}
+
 @end

--- a/NCMBTests/NCMBTests/NCMBUserSpec.m
+++ b/NCMBTests/NCMBTests/NCMBUserSpec.m
@@ -365,7 +365,7 @@ describe(@"NCMBUser", ^{
         }];
     });
     
-    it(@"should is mail address confirm", ^{
+    it(@"should return YES when mail address confirm is setting YES", ^{
         
         NCMBUser *user = [NCMBUser user];
         
@@ -375,7 +375,7 @@ describe(@"NCMBUser", ^{
         
     });
     
-    it(@"should is not mail address confirm", ^{
+    it(@"should return NO when mail address confirm is setting invalid params", ^{
         
         NCMBUser *user = [NCMBUser user];
         

--- a/NCMBTests/NCMBTests/NCMBUserSpec.m
+++ b/NCMBTests/NCMBTests/NCMBUserSpec.m
@@ -365,6 +365,34 @@ describe(@"NCMBUser", ^{
         }];
     });
     
+    it(@"should is mail address confirm", ^{
+        
+        NCMBUser *user = [NCMBUser user];
+        
+        [user setObject:[NSNumber numberWithBool:YES] forKey:@"mailAddressConfirm"];
+        
+        expect([user isMailAddressConfirm]).to.beTruthy();
+        
+    });
+    
+    it(@"should is not mail address confirm", ^{
+        
+        NCMBUser *user = [NCMBUser user];
+        
+        [user setObject:[NSNumber numberWithBool:NO] forKey:@"mailAddressConfirm"];
+        expect([user isMailAddressConfirm]).toNot.beTruthy();
+        
+        [user setObject:@"" forKey:@"mailAddressConfirm"];
+        expect([user isMailAddressConfirm]).toNot.beTruthy();
+        
+        [user setObject:@"aaa" forKey:@"mailAddressConfirm"];
+        expect([user isMailAddressConfirm]).toNot.beTruthy();
+        
+        [user setObject:[NSNull null] forKey:@"mailAddressConfirm"];
+        expect([user isMailAddressConfirm]).toNot.beTruthy();
+        
+    });
+    
     afterEach(^{
         
     });


### PR DESCRIPTION
## 概要(Summary)

Fixed #56 メールアドレスが確認済みかを把握するメソッドの追加
- isMailAddressConfirmメソッドの追加

## 動作確認手順(Step for Confirmation)

Run the NCMBUserSpec.
