### PR TITLE
NCMBFileのgetDataInBackgroundWithBlockメソッドでcastのエラー

### DIFF
--- a/NCMB/NCMBFile.m
+++ b/NCMB/NCMBFile.m
@@ -329,6 +329,9 @@ static NSMutableData *resultData = nil;
                         self.file = responseData;
                     }
                     if(resultBlock){
+                        if (![responseData isKindOfClass:[NSData class]]) {
+                            responseData = nil;
+                        }
                         resultBlock(responseData,errorBlock);
                     }
                 }];


### PR DESCRIPTION
お世話になっております。
AppLabの原田と申します。
表題の件で、アプリが申請できないため、困っております。
修正箇所はわかったんですが、これでいいのかわからないです。
対応策を教えていただけると幸いです。

## 概要(Summary)
NCMBFileクラスのgetDataInBackgroundWithBlockメソッドで、
取得するファイルが存在しない場合に、castで失敗してしまうようです。
![image](https://cloud.githubusercontent.com/assets/710780/25237308/3a0f1388-2625-11e7-82b6-0a815bdc3c64.png)
下記のエラーが表示されました。
```
Could not cast value of type '__NSDictionaryI' (0x10bb23288) to 'NSData' (0x10bb22338).
```
xcode8.3.1からの不具合かと思われます。
クラス判定をいれたら、正常に動作しました。
他の対応方法等あれば、ご教示いただけると幸いです。
よろしくお願い致します。

## 動作確認手順(Step for Confirmation)
なし
