### PR TITLE
NCMBFileのgetDataInBackgroundWithBlockメソッドでcastのエラー（テストコードあり）

### DIFF
--- a/NCMB/NCMBFile.m
+++ b/NCMB/NCMBFile.m
@@ -330,7 +330,7 @@ static NSMutableData *resultData = nil;
                         self.file = responseData;
                     }
                     if(resultBlock){
-                        resultBlock(responseData,errorBlock);
+                        resultBlock(self.file,errorBlock);
                     }
                 }];
             }else{


### PR DESCRIPTION
## 概要(Summary)

#110 NCMBFileのgetDataInBackgroundWithBlockメソッドでcastのエラー

確認したところ、swiftでクラッシュが発生しました。
修正内容をgetDataメソッドと同じように修正しました。

## 動作確認手順(Step for Confirmation)

Run the unit test.
